### PR TITLE
Pull Request - Updated Python Bindings working on Gr 3.10.6 and build fix for Windows MSVC

### DIFF
--- a/lib/tmcc_decoder_impl.cc
+++ b/lib/tmcc_decoder_impl.cc
@@ -263,10 +263,10 @@ namespace gr {
             tmcc_decoder_impl::tmcc_parity_check( )
             {
 
-                int n = 273,
+                static const int n = 273,
                     k = 191,
-                    r = n-k,
-                    i, j, s;
+                    r = n-k;
+                int i, j, s;
 
                 char syndrome[r];
                 //unsigned char tmcc_large[n];
@@ -553,12 +553,12 @@ namespace gr {
                             //d_symbol_index = 203;
 
                             // Then, we print the full tmcc
-                            /*
+
                                for (int i = 0; i < d_symbols_per_frame; i++)
                                printf("%i", d_rcv_tmcc_data[i]);
                                printf("\n");
 
-*/
+
                             if (d_print_params)
                             {
                                 tmcc_print();

--- a/python/isdbt/bindings/CMakeLists.txt
+++ b/python/isdbt/bindings/CMakeLists.txt
@@ -55,12 +55,25 @@ GR_PYBIND_MAKE_OOT(isdbt
    gr::isdbt
    "${isdbt_python_files}")
 
-# copy in bindings .so file for use in QA test module
-add_custom_target(
-  copy_bindings_for_tests ALL
-  COMMAND
-    ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/*.so"
-    ${CMAKE_BINARY_DIR}/test_modules/gnuradio/isdbt/
-  DEPENDS isdbt_python)
+
+# copy in bindings .so / .lib file for use in QA test module
+IF (WIN32)
+  # windows uses .lib
+  add_custom_target(
+    copy_bindings_for_tests ALL
+    COMMAND
+      ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/isdbt_python.lib"
+      ${CMAKE_BINARY_DIR}/test_modules/gnuradio/isdbt/
+    DEPENDS isdbt_python)
+
+ELSE()
+  # linux uses .so
+  add_custom_target(
+    copy_bindings_for_tests ALL
+    COMMAND
+      ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/*.so"
+      ${CMAKE_BINARY_DIR}/test_modules/gnuradio/isdbt/
+    DEPENDS isdbt_python)
+ENDIF()
 
 install(TARGETS isdbt_python DESTINATION ${GR_PYTHON_DIR}/gnuradio/isdbt COMPONENT pythonapi)

--- a/python/isdbt/bindings/bit_deinterleaver_python.cc
+++ b/python/isdbt/bindings/bit_deinterleaver_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(bit_deinterleaver.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(667b74b67fbde392e5b0d4fa4535c0f9)                     */
+/* BINDTOOL_HEADER_FILE_HASH(06ee8266c9fad6207e3de6946848a007)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/byte_deinterleaver_python.cc
+++ b/python/isdbt/bindings/byte_deinterleaver_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(byte_deinterleaver.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(c0dc7d96e5888a641c6f4f53f7294d17)                     */
+/* BINDTOOL_HEADER_FILE_HASH(037271b5046158c630b8ec7bf05e0625)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/byte_interleaver_python.cc
+++ b/python/isdbt/bindings/byte_interleaver_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(byte_interleaver.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(fba7cb481ffd846e2f5caef1c4d8149d)                     */
+/* BINDTOOL_HEADER_FILE_HASH(0d6e22f6801b5ad71a3760ba9e29126c)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/carrier_modulation_python.cc
+++ b/python/isdbt/bindings/carrier_modulation_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(carrier_modulation.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(f34f1b4fa8c2a703cd026dee4cd0effb)                     */
+/* BINDTOOL_HEADER_FILE(carrier_modulation.h)                                      */
+/* BINDTOOL_HEADER_FILE_HASH(f7260db1a3660b90e35ae82857ec63ee)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/energy_descrambler_python.cc
+++ b/python/isdbt/bindings/energy_descrambler_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(energy_descrambler.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(b31be5d7bc38b4b39e18cd1bbec11474)                     */
+/* BINDTOOL_HEADER_FILE(energy_descrambler.h)                                      */
+/* BINDTOOL_HEADER_FILE_HASH(2e4e03e5c77256858f34c3446ad43feb)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/energy_dispersal_python.cc
+++ b/python/isdbt/bindings/energy_dispersal_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(energy_dispersal.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(9115de36edd0d618dccd3692445ffa4e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(31d564298936a247e399cb3b546122d0)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/frequency_deinterleaver_python.cc
+++ b/python/isdbt/bindings/frequency_deinterleaver_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(frequency_deinterleaver.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(875b8b92244b1f16f80ed935df0d5d36)                     */
+/* BINDTOOL_HEADER_FILE(frequency_deinterleaver.h)                                 */
+/* BINDTOOL_HEADER_FILE_HASH(cf6391c197ca3c8efff6651d916c11e7)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/frequency_interleaver_python.cc
+++ b/python/isdbt/bindings/frequency_interleaver_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(frequency_interleaver.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(2df79c71b5a9eb6c25b36d4ae0cccc9a)                     */
+/* BINDTOOL_HEADER_FILE(frequency_interleaver.h)                                   */
+/* BINDTOOL_HEADER_FILE_HASH(4a0db39772f9300640ef0ededfab9c20)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/hierarchical_combinator_python.cc
+++ b/python/isdbt/bindings/hierarchical_combinator_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(hierarchical_combinator.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(9967d9c95bccd500aba7fb8a01769b01)                     */
+/* BINDTOOL_HEADER_FILE(hierarchical_combinator.h)                                 */
+/* BINDTOOL_HEADER_FILE_HASH(87d6830ba485b9eb688517fe19bf69ca)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/ofdm_synchronization_python.cc
+++ b/python/isdbt/bindings/ofdm_synchronization_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(ofdm_synchronization.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(868e570369c1b442bf6f731a0a028891)                     */
+/* BINDTOOL_HEADER_FILE(ofdm_synchronization.h)                                    */
+/* BINDTOOL_HEADER_FILE_HASH(e3059003b66b2d6b156363156473f5ec)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/pilot_signals_python.cc
+++ b/python/isdbt/bindings/pilot_signals_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(pilot_signals.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(4f5c3ffd3ce3542e5f5ab2d3499fa76e)                     */
+/* BINDTOOL_HEADER_FILE(pilot_signals.h)                                           */
+/* BINDTOOL_HEADER_FILE_HASH(375014bc1181a847cabbfd725dc7e520)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/reed_solomon_dec_isdbt_python.cc
+++ b/python/isdbt/bindings/reed_solomon_dec_isdbt_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(reed_solomon_dec_isdbt.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a1444d988ea18ca6ce09375056c87758)                     */
+/* BINDTOOL_HEADER_FILE(reed_solomon_dec_isdbt.h)                                  */
+/* BINDTOOL_HEADER_FILE_HASH(c6049656aa8603da08d9c82fe6f251e0)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/subset_of_carriers_python.cc
+++ b/python/isdbt/bindings/subset_of_carriers_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(subset_of_carriers.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(20d76efd9a07f91fed34a51cb1dab06d)                     */
+/* BINDTOOL_HEADER_FILE_HASH(673fa4f7dbe839ccbeef1498bd9c1cb6)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/symbol_demapper_python.cc
+++ b/python/isdbt/bindings/symbol_demapper_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(symbol_demapper.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(6907fe9f67df5de09abcba7ba6e25a93)                     */
+/* BINDTOOL_HEADER_FILE(symbol_demapper.h)                                         */
+/* BINDTOOL_HEADER_FILE_HASH(2a5fe4fb4db82665906d1d888c704253)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/time_deinterleaver_python.cc
+++ b/python/isdbt/bindings/time_deinterleaver_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(time_deinterleaver.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(10c96da390dc40084dd497c276f955b5)                     */
+/* BINDTOOL_HEADER_FILE(time_deinterleaver.h)                                      */
+/* BINDTOOL_HEADER_FILE_HASH(7f8214066e2b623252b8adeaa27b31f4)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/time_interleaver_python.cc
+++ b/python/isdbt/bindings/time_interleaver_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(time_interleaver.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(eb6f048a73f405735e9e1d79365f0258)                     */
+/* BINDTOOL_HEADER_FILE_HASH(da036f25fb30fb9f9d98803a72fa51f5)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/tmcc_decoder_python.cc
+++ b/python/isdbt/bindings/tmcc_decoder_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(tmcc_decoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(0d332aa957272d6d06081dacfc4fb6ac)                     */
+/* BINDTOOL_HEADER_FILE_HASH(ee82f806eacde366472397cd10a478d3)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/tmcc_encoder_python.cc
+++ b/python/isdbt/bindings/tmcc_encoder_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(tmcc_encoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(9e68da5d11858e0c90d41e26c3607fc0)                     */
+/* BINDTOOL_HEADER_FILE(tmcc_encoder.h)                                            */
+/* BINDTOOL_HEADER_FILE_HASH(3e5f97cf7160283272e0e52c42477002)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/python/isdbt/bindings/viterbi_decoder_python.cc
+++ b/python/isdbt/bindings/viterbi_decoder_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(viterbi_decoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(79a81c82e1f6ba689c28ba1dc206ce5f)                     */
+/* BINDTOOL_HEADER_FILE_HASH(333d5fdcf2925aff2e78c60a1f71b672)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
I've updated the python bindings manually changing the hashes of the header files and changed tmcc_decoder_imp.cc to build in Windows x64 under MSVC and conda install.

Build system info:
Windows 11 23H2 (build 22631.2338) x64
Visual Studio 2019 v16.11.25 with MSVC x64 v19.29.30148
CMake 3.21.1
Ninja 1.11.1
GnuRadio 3.10.6 instaleld via CondaInstall

Screenshot of flowgraph demodulating local tv station (Brazil)
![image](https://github.com/git-artes/gr-isdbt/assets/58897843/31d9a482-7a0d-425b-a5b0-5549fd131784)

